### PR TITLE
fix: correct GitHub workflow paths and improve OGP error handling

### DIFF
--- a/app/articles/2024/0813/tech-stack-of-ios.mdx
+++ b/app/articles/2024/0813/tech-stack-of-ios.mdx
@@ -179,7 +179,7 @@ dorny/paths-filterを利用して対象のソースコードが更新された�
 
 <img src="/assets/2025/0323/tech-stack-of-ios/github-actions.webp" alt="GitHub Actions Workflow" />
 
-<ExternalOgp url="https://github.com/0x1-company/ios-monorepo/blob/main/github/workflows/app.yml" />
+<ExternalOgp url="https://github.com/0x1-company/ios-monorepo/blob/main/.github/workflows/app.yml" />
 
 
 
@@ -201,7 +201,7 @@ GitHub Actionsにrelease workflowを組んでいます。
 
 <img src="/assets/2025/0323/tech-stack-of-ios/release-workflow.webp" alt="リリースワークフロー" />
 
-<ExternalOgp url="https://github.com/0x1-company/ios-monorepo/blob/main/github/workflows/release.yml" />
+<ExternalOgp url="https://github.com/0x1-company/ios-monorepo/blob/main/.github/workflows/release.yml" />
 
 Run workflowを押すとすべてのCFBundleShortVersionStringが更新されたPull Requestの作成、Approve、mergeがすべて自動で行われます。
 

--- a/app/lib/fetchOgp.ts
+++ b/app/lib/fetchOgp.ts
@@ -33,7 +33,8 @@ export const fetchOgp = async (url: string) => {
 
     return ogp;
   } catch (e) {
-    console.error(e);
+    console.warn(`[fetchOgp] Warning: Failed to fetch OGP data for ${url}. Using fallback.`);
+    return ogp;
   }
 };
 


### PR DESCRIPTION
## Summary
- Fix GitHub workflow file paths from github/workflows/ to .github/workflows/ in tech stack article
- Improve error handling in fetchOgp with warning instead of error and explicit fallback return

## Test plan
- [ ] Verify the corrected GitHub workflow links work properly in the article
- [ ] Test OGP fetching with invalid URLs to confirm improved error handling

🤖 Generated with [Claude Code](https://claude.ai/code)